### PR TITLE
[BUGFIX] Make 'digest-crc' a runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,6 @@ gemspec
 
 gem 'bundler', '>=2.2', '<3'
 
-gem 'digest-crc'
-
 group :develoment do
   gem 'rake', '~> 13.0'
   gem 'rspec', '~> 3.12'

--- a/packetgen.gemspec
+++ b/packetgen.gemspec
@@ -41,4 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'interfacez', '~>1.0'
   spec.add_dependency 'pcaprub', '~>0.13.0'
   spec.add_dependency 'rasn1', '~>0.13', '>=0.13.1'
+  spec.add_dependency 'digest-crc', '~> 0'
 end


### PR DESCRIPTION
#123 Added code that is using the `digest-crc` gem. However, it listed the gem in the `Gemfile`, not in the `gemspec`.
This causes projects using `packengen` which aren't including the `digest-crc` gem themselves (or another gem that uses it) to break.

The gem should have been listed as a runtime dependency in the `gemspec` file.

Gems listed in the `Gemfile` are not taken into account by Bundler when searching for or installing dependencies.